### PR TITLE
Fix horizontal overflow on mobiles

### DIFF
--- a/app/components/LandingPage/frontPage.tsx
+++ b/app/components/LandingPage/frontPage.tsx
@@ -71,7 +71,7 @@ export default function FrontPage() {
             alignItems="Start"
             justifyContent="center"
           >
-            <Box width="sm" alignSelf="baseline" marginBottom="2rem">
+            <Box style={{ width: "min(24rem,95vw" }} alignSelf="baseline" marginBottom="2rem">
               <Heading lineHeight="3rem" marginRight="2rem">
                 Share your needs
               </Heading>
@@ -110,7 +110,7 @@ export default function FrontPage() {
               specialWish="Buy only Bio and vegan products please :)"
               itemsList={["Bread", "Jam (Strawberry)", "Agave sirup (from Alnatura)"]}
             />
-            <Box width="sm" alignSelf="unset" marginBottom="2rem">
+            <Box style={{ width: "min(24rem,95vw" }} alignSelf="unset" marginBottom="2rem">
               <Heading textAlign="right" lineHeight="3rem" marginLeft="2rem">
                 Help others!
               </Heading>
@@ -130,7 +130,12 @@ export default function FrontPage() {
             alignItems="Start"
             justifyContent="center"
           >
-            <Box width="sm" alignSelf="baseline" marginBottom="2rem" marginTop="0.5rem">
+            <Box
+              style={{ width: "min(24rem,95vw" }}
+              alignSelf="baseline"
+              marginBottom="2rem"
+              marginTop="0.5rem"
+            >
               <Heading lineHeight="3rem" marginRight="2rem">
                 Chat to connect
               </Heading>

--- a/app/components/LandingPage/frontPage.tsx
+++ b/app/components/LandingPage/frontPage.tsx
@@ -71,7 +71,7 @@ export default function FrontPage() {
             alignItems="Start"
             justifyContent="center"
           >
-            <Box style={{ width: "min(24rem,95vw" }} alignSelf="baseline" marginBottom="2rem">
+            <Box style={{ width: "min(24rem,95vw)" }} alignSelf="baseline" marginBottom="2rem">
               <Heading lineHeight="3rem" marginRight="2rem">
                 Share your needs
               </Heading>
@@ -110,7 +110,7 @@ export default function FrontPage() {
               specialWish="Buy only Bio and vegan products please :)"
               itemsList={["Bread", "Jam (Strawberry)", "Agave sirup (from Alnatura)"]}
             />
-            <Box style={{ width: "min(24rem,95vw" }} alignSelf="unset" marginBottom="2rem">
+            <Box style={{ width: "min(24rem,95vw)" }} alignSelf="unset" marginBottom="2rem">
               <Heading textAlign="right" lineHeight="3rem" marginLeft="2rem">
                 Help others!
               </Heading>
@@ -131,7 +131,7 @@ export default function FrontPage() {
             justifyContent="center"
           >
             <Box
-              style={{ width: "min(24rem,95vw" }}
+              style={{ width: "min(24rem,95vw)" }}
               alignSelf="baseline"
               marginBottom="2rem"
               marginTop="0.5rem"

--- a/app/components/LandingPage/frontPageChat.tsx
+++ b/app/components/LandingPage/frontPageChat.tsx
@@ -35,7 +35,7 @@ export default function Chat() {
     <Flex
       textAlign="center"
       direction="column"
-      style={{ width: "min(24rem,95vw" }}
+      style={{ width: "min(24rem,95vw)" }}
       maxWidth="600px"
       alignSelf="center"
     >

--- a/app/components/LandingPage/frontPageChat.tsx
+++ b/app/components/LandingPage/frontPageChat.tsx
@@ -32,7 +32,13 @@ export default function Chat() {
   let date8 = new Date()
 
   return (
-    <Flex textAlign="center" direction="column" width="sm" maxWidth="600px" alignSelf="center">
+    <Flex
+      textAlign="center"
+      direction="column"
+      style={{ width: "min(24rem,95vw" }}
+      maxWidth="600px"
+      alignSelf="center"
+    >
       <Heading
         as="h2"
         fontFamily="Raleway"

--- a/app/components/LandingPage/frontPageOwnedList.tsx
+++ b/app/components/LandingPage/frontPageOwnedList.tsx
@@ -39,7 +39,7 @@ export default function OwnedList({
     <Flex
       flexDirection="column"
       borderWidth="2px"
-      width="sm"
+      style={{ width: "min(24rem,95vw" }}
       padding="0.5rem"
       borderRadius="lg"
       borderColor="brandGreen.800"

--- a/app/components/LandingPage/frontPageOwnedList.tsx
+++ b/app/components/LandingPage/frontPageOwnedList.tsx
@@ -39,7 +39,7 @@ export default function OwnedList({
     <Flex
       flexDirection="column"
       borderWidth="2px"
-      style={{ width: "min(24rem,95vw" }}
+      style={{ width: "min(24rem,95vw)" }}
       padding="0.5rem"
       borderRadius="lg"
       borderColor="brandGreen.800"

--- a/app/components/LandingPage/frontPagePublicList.tsx
+++ b/app/components/LandingPage/frontPagePublicList.tsx
@@ -39,7 +39,7 @@ export default function PublicList({
       justifyContent="space-between"
       flexDirection="column"
       borderWidth="2px"
-      width="sm"
+      style={{ width: "min(24rem,95vw" }}
       borderRadius="lg"
       borderColor="brandGreen.800"
       onClick={onToggle}

--- a/app/components/LandingPage/frontPagePublicList.tsx
+++ b/app/components/LandingPage/frontPagePublicList.tsx
@@ -39,7 +39,7 @@ export default function PublicList({
       justifyContent="space-between"
       flexDirection="column"
       borderWidth="2px"
-      style={{ width: "min(24rem,95vw" }}
+      style={{ width: "min(24rem,95vw)" }}
       borderRadius="lg"
       borderColor="brandGreen.800"
       onClick={onToggle}

--- a/app/components/acceptedList.tsx
+++ b/app/components/acceptedList.tsx
@@ -58,7 +58,7 @@ export default function AcceptedList({
       justifyContent="space-between"
       flexDirection="column"
       borderWidth="2px"
-      width="sm"
+      style={{ width: "min(24rem,95vw" }}
       padding="0.5rem"
       margin="0.5rem"
       borderRadius="lg"

--- a/app/components/acceptedList.tsx
+++ b/app/components/acceptedList.tsx
@@ -58,7 +58,7 @@ export default function AcceptedList({
       justifyContent="space-between"
       flexDirection="column"
       borderWidth="2px"
-      style={{ width: "min(24rem,95vw" }}
+      style={{ width: "min(24rem,95vw)" }}
       padding="0.5rem"
       margin="0.5rem"
       borderRadius="lg"

--- a/app/components/layout.tsx
+++ b/app/components/layout.tsx
@@ -75,12 +75,16 @@ export default function Layout({
             alignItems="flex-end"
             marginTop="5px"
           >
-            <HStack as="a" href="/">
-              <Image src="/logo_1.png" width="90" alt="entel logo" height="90" />
-              <Heading fontSize="6xl" fontWeight="extrabold" fontFamily="Raleway">
-                entel
-              </Heading>
-            </HStack>
+            <Link href="/">
+              <HStack>
+                {(user || !isMobile) && (
+                  <Image src="/logo_1.png" width="90" alt="entel logo" height="90" />
+                )}
+                <Heading fontSize="6xl" fontWeight="extrabold" fontFamily="Raleway">
+                  entel
+                </Heading>
+              </HStack>
+            </Link>
             <Flex
               direction="row"
               justifyContent="space-between"

--- a/app/components/ownedList.tsx
+++ b/app/components/ownedList.tsx
@@ -51,7 +51,7 @@ export default function OwnedList({
     <Flex
       flexDirection="column"
       borderWidth="2px"
-      width="sm"
+      style={{ width: "min(24rem,95vw" }}
       padding="0.5rem"
       margin="0.5rem"
       borderRadius="lg"

--- a/app/components/ownedList.tsx
+++ b/app/components/ownedList.tsx
@@ -51,7 +51,7 @@ export default function OwnedList({
     <Flex
       flexDirection="column"
       borderWidth="2px"
-      style={{ width: "min(24rem,95vw" }}
+      style={{ width: "min(24rem,95vw)" }}
       padding="0.5rem"
       margin="0.5rem"
       borderRadius="lg"

--- a/app/components/publicList.tsx
+++ b/app/components/publicList.tsx
@@ -55,7 +55,7 @@ export default function PublicList({
       justifyContent="space-between"
       flexDirection="column"
       borderWidth="2px"
-      width="sm"
+      style={{ width: "min(24rem,95vw" }}
       margin="0.5rem"
       borderRadius="lg"
       borderColor="brandGreen.800"

--- a/app/components/publicList.tsx
+++ b/app/components/publicList.tsx
@@ -55,7 +55,7 @@ export default function PublicList({
       justifyContent="space-between"
       flexDirection="column"
       borderWidth="2px"
-      style={{ width: "min(24rem,95vw" }}
+      style={{ width: "min(24rem,95vw)" }}
       margin="0.5rem"
       borderRadius="lg"
       borderColor="brandGreen.800"


### PR DESCRIPTION
- Fixed horizontal overflow by comparing `95vw` with `sm`-width (24rem)
- Removed logo in header on landingpage for mobiles

fix #55 